### PR TITLE
fix: stop swallowing extraction errors in background task

### DIFF
--- a/perfectframe/extractor_manager.py
+++ b/perfectframe/extractor_manager.py
@@ -44,8 +44,6 @@ class ExtractorManager:
         """Run extraction process and clean after it's done."""
         try:
             extractor.process()
-        except Exception:
-            logger.exception("Extraction failed with error")
         finally:
             with cls._lock:
                 cls._active_extractor = None

--- a/tests/unit/extractor_manager_test.py
+++ b/tests/unit/extractor_manager_test.py
@@ -42,15 +42,15 @@ def test_run_extractor(mocker):
     mock_extractor.process.assert_called_once()
 
 
-def test_run_extractor_logs_exception_on_failure(mocker, caplog):
+def test_run_extractor_propagates_exception_and_resets_active(mocker):
     mock_extractor = mocker.MagicMock()
     mock_extractor.process.side_effect = RuntimeError("Test error")
+    ExtractorManager._active_extractor = ExtractorName.BEST_FRAMES
 
-    with caplog.at_level("ERROR"):
+    with pytest.raises(RuntimeError, match="Test error"):
         ExtractorManager._ExtractorManager__run_extractor(mock_extractor)
 
     mock_extractor.process.assert_called_once()
-    assert "Extraction failed with error" in caplog.text
     assert ExtractorManager._active_extractor is None
 
 


### PR DESCRIPTION
## Problem

`ExtractorManager.__run_extractor` wrapped `extractor.process()` in a broad `except Exception` that logged a single line ("Extraction failed with error") and swallowed the exception. The real traceback was lost.

This actively hid a failure: when an extraction crashed, `_active_extractor` was reset to `None`, so `/v2/status` reported the service as idle/done even though nothing was produced. The e2e tests could only observe the symptom (`No output files were created`) with no way to see the underlying cause.

## Change

Remove the `except` block. Keep `finally`.

- Extraction runs in a FastAPI `BackgroundTask`, so the exception propagates to Starlette and is logged with a **full traceback** in the container logs.
- The `finally` block still resets `_active_extractor`, so a crashed extraction does not brick the single-extractor lock (no permanent 409).
- No client-facing behavior change: the response (`started`) is already sent before the background task runs, so there was never a 500 to lose.

## Result

Background-task failures are now diagnosable from container logs instead of being silently discarded.