### PR TITLE
fix: resolve open security alerts (pygments, pip, base image CVEs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ LABEL authors="BKDDFS"
 # Install uv (fixed version)
 COPY --from=ghcr.io/astral-sh/uv:0.9.27 /uv /bin/uv
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
     libgl1 \
     libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
+    python -m pip uninstall -y pip && \
     useradd --create-home --shell /bin/bash appuser
 
 # Set working directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ test = [
     "testcontainers>=4.14.0", # Docker containers for e2e
 ]
 
+[tool.uv]
+# Security overrides for transitive dev/test dependencies (kept out of prod deps)
+override-dependencies = [
+    "pygments>=2.20.0",  # CVE fix: ReDoS in GUID regex (pytest dep)
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py313"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.12, <3.14"
 
+[manifest]
+overrides = [{ name = "pygments", specifier = ">=2.20.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -600,11 +603,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the 4 open security alerts in the repo. No secrets leaked; most prior alerts already fixed via dependabot history.

| Alert | Issue | Fix | Status |
|-------|-------|-----|--------|
| Dependabot #56 | Pygments ReDoS (GUID regex) | override `pygments>=2.20.0` | fully fixed |
| Code scan #1869 | pip 25.3 path traversal (CVE-2026-1703) | uninstall unused base-image pip | fully fixed |
| Code scan #1958 | gnutls DoS (CVE-2025-14831) | `apt-get upgrade` | best-effort* |
| Code scan #1868 | libxml2 leak (CVE-2026-1757) | `apt-get upgrade` | best-effort* |

\* No upstream Debian fix yet (`Fixed Version:` empty). `apt-get upgrade` clears these once Debian ships patched packages.

## Changes

- **pyproject.toml / uv.lock** — `[tool.uv] override-dependencies` forcing `pygments>=2.20.0`. Kept out of prod deps (transitive via pytest, test-only). Re-locked: 2.19.2 → 2.20.0.
- **Dockerfile** — `apt-get upgrade -y` for latest Debian security patches; `pip uninstall -y pip` to remove the base image's unused pip 25.3 (uv manages the venv, runtime never invokes pip).

## Verification

- `uv lock --locked` consistent.
- Docker build succeeds; confirmed in image: pip absent from site-packages, `import perfectframe.app` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)