### PR TITLE
ci: replace Codecov with SonarCloud coverage

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,12 +32,6 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Run tests with coverage
         run: uv run --group test pytest --cov=perfectframe --cov-report=xml --cov-fail-under=100
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: true
 
   test-docker:
     needs: pre-commit

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,37 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonar:
+    name: SonarCloud Analysis
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Run tests with coverage
+        run: uv run --group test pytest --cov=perfectframe --cov-report=xml
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
     <p align="center">
         <img alt="Github Created At" src="https://img.shields.io/github/created-at/BKDDFS/PerfectFrameAI">
         <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/BKDDFS/PerfectFrameAI">
-        <a href="https://codecov.io/github/BKDDFS/PerfectFrameAI" >
-        <img src="https://codecov.io/github/BKDDFS/PerfectFrameAI/graph/badge.svg?token=GT9TGKBGYI"/>
+        <a href="https://sonarcloud.io/summary/new_code?id=BKDDFS_PerfectFrameAI" >
+        <img src="https://sonarcloud.io/api/project_badges/measure?project=BKDDFS_PerfectFrameAI&metric=coverage"/>
         </a>
         <img alt="GitHub Tag" src="https://img.shields.io/github/v/tag/BKDDFS/PerfectFrameAI">
         <img alt="shamefile" src="https://img.shields.io/badge/tracked_with-shamefile-fe3434">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.organization=BKDDFS
+sonar.projectKey=BKDDFS_PerfectFrameAI
+sonar.projectName=PerfectFrameAI
+
+sonar.sources=perfectframe
+sonar.tests=tests
+
+sonar.exclusions=**/tests/**,**/__pycache__/**
+sonar.cpd.exclusions=**/tests/**
+
+sonar.python.version=3.13
+sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.organization=BKDDFS
+sonar.organization=bkddfs
 sonar.projectKey=BKDDFS_PerfectFrameAI
 sonar.projectName=PerfectFrameAI
 


### PR DESCRIPTION
## What & why

Replaces Codecov with SonarCloud coverage (same setup as omniviser/omniray).

## Changes
- **`.github/workflows/sonar.yml`** (new) — dedicated SonarCloud job: fork guard, `fetch-depth: 0`, Python 3.13, uv, tests with `--cov-report=xml`, `SonarSource/sonarqube-scan-action` (SHA-pinned v8.1.0).
- **`run_tests.yml`** — removed Codecov upload step; `test` job only runs tests with `--cov-fail-under=100`.
- **`sonar-project.properties`** (new) — `org=bkddfs`, `key=BKDDFS_PerfectFrameAI`, sources=`perfectframe`, coverage from `coverage.xml`.
- **`README.md`** — Codecov badge replaced with SonarCloud coverage badge.

## Manual setup (outside repo, done)
1. Generated new `SONAR_TOKEN` and added it to both Actions and Dependabot secrets.
2. Disabled Automatic Analysis on SonarCloud (conflicts with CI-based scan).
3. Optional: remove the unused `CODECOV_TOKEN` secret.